### PR TITLE
Support builders added to the client SDK.

### DIFF
--- a/src/LaunchDarkly.OpenFeature.ServerProvider/LaunchDarkly.OpenFeature.ServerProvider.csproj
+++ b/src/LaunchDarkly.OpenFeature.ServerProvider/LaunchDarkly.OpenFeature.ServerProvider.csproj
@@ -39,13 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.ServerSdk" Version="[6.3.2,7.0)" />
-<!--    <PackageReference Include="OpenFeature" Version="0.3.0" />-->
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="OpenFeatureSDK">
-      <HintPath>..\..\..\..\open-feature/dotnet-sdk/src/OpenFeatureSDK/bin/Debug/netstandard2.0/OpenFeatureSDK.dll</HintPath>
-    </Reference>
+    <PackageReference Include="OpenFeature" Version="0.4.0" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/src/LaunchDarkly.OpenFeature.ServerProvider/LaunchDarkly.OpenFeature.ServerProvider.csproj
+++ b/src/LaunchDarkly.OpenFeature.ServerProvider/LaunchDarkly.OpenFeature.ServerProvider.csproj
@@ -39,7 +39,13 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.ServerSdk" Version="[6.3.2,7.0)" />
-    <PackageReference Include="OpenFeature" Version="0.3.0" />
+<!--    <PackageReference Include="OpenFeature" Version="0.3.0" />-->
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="OpenFeatureSDK">
+      <HintPath>..\..\..\..\open-feature/dotnet-sdk/src/OpenFeatureSDK/bin/Debug/netstandard2.0/OpenFeatureSDK.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/src/LaunchDarkly.OpenFeature.ServerProvider/LdValueExtensions.cs
+++ b/src/LaunchDarkly.OpenFeature.ServerProvider/LdValueExtensions.cs
@@ -29,12 +29,12 @@ namespace LaunchDarkly.OpenFeature.ServerProvider
                 case LdValueType.Array:
                     return new Value(value.List.Select(ToValue).ToList());
                 case LdValueType.Object:
-                    var ofStructure = new Structure();
+                    var structureBuilder = Structure.Builder();
                     foreach (var kvp in value.Dictionary)
                     {
-                        ofStructure.Add(kvp.Key, ToValue(kvp.Value));
+                        structureBuilder.Set(kvp.Key, ToValue(kvp.Value));
                     }
-                    return new Value(ofStructure);
+                    return new Value(structureBuilder.Build());
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/EvalContextConverterTests.cs
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/EvalContextConverterTests.cs
@@ -20,17 +20,17 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
         [Fact]
         public void ItCanHandleBuiltInAttributes()
         {
-            var evaluationContext = new EvaluationContext();
-            evaluationContext.Add("targetingKey", "the-key");
-            evaluationContext.Add("secondary", "secondary");
-            evaluationContext.Add("name", "name");
-            evaluationContext.Add("firstName", "firstName");
-            evaluationContext.Add("lastName", "lastName");
-            evaluationContext.Add("email", "email");
-            evaluationContext.Add("avatar", "avatar");
-            evaluationContext.Add("ip", "ip");
-            evaluationContext.Add("country", "country");
-            evaluationContext.Add("anonymous", true);
+            var evaluationContext = EvaluationContext.Builder()
+                .Set("targetingKey", "the-key")
+                .Set("secondary", "secondary")
+                .Set("name", "name")
+                .Set("firstName", "firstName")
+                .Set("lastName", "lastName")
+                .Set("email", "email")
+                .Set("avatar", "avatar")
+                .Set("ip", "ip")
+                .Set("country", "country")
+                .Set("anonymous", true).Build();
 
             var convertedUser = _converter.ToLdUser(evaluationContext);
 
@@ -54,19 +54,20 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
         [Fact]
         public void ItAllowsNullForBuiltInAttributes()
         {
-            var evaluationContext = new EvaluationContext();
-            evaluationContext.Add("targetingKey", "the-key");
-            evaluationContext.Add("secondary", (string)null);
-            evaluationContext.Add("name", (string)null);
-            evaluationContext.Add("firstName", (string)null);
-            evaluationContext.Add("lastName", (string)null);
-            evaluationContext.Add("email", (string)null);
-            evaluationContext.Add("avatar", (string)null);
-            evaluationContext.Add("ip", (string)null);
-            evaluationContext.Add("country", (string)null);
-            // Cannot just pass in null, cannot pass in a nullable bool, have to either case to a reference type like
-            // string, or construct a value instance and pass that.
-            evaluationContext.Add("anonymous", new Value());
+            var evaluationContext = EvaluationContext.Builder()
+                .Set("targetingKey", "the-key")
+                .Set("secondary", (string) null)
+                .Set("name", (string) null)
+                .Set("firstName", (string) null)
+                .Set("lastName", (string) null)
+                .Set("email", (string) null)
+                .Set("avatar", (string) null)
+                .Set("ip", (string) null)
+                .Set("country", (string) null)
+                // Cannot just pass in null, cannot pass in a nullable bool, have to either case to a reference type like
+                // string, or construct a value instance and pass that.
+                .Set("anonymous", new Value())
+                .Build();
 
             var convertedUser = _converter.ToLdUser(evaluationContext);
 
@@ -81,7 +82,7 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
         [Fact]
         public void ItLogsAndErrorWhenThereIsNoTargetingKey()
         {
-            _converter.ToLdUser(new EvaluationContext());
+            _converter.ToLdUser(EvaluationContext.Empty);
             Assert.True(_logCapture.HasMessageWithText(LogLevel.Error,
                 "The EvaluationContext must contain either a 'targetingKey' or a 'key' and the type" +
                 "must be a string."));
@@ -90,7 +91,7 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
         [Fact]
         public void ItLogsAWarningWhenBothTargetingKeyAndKeyAreDefined()
         {
-            _converter.ToLdUser(new EvaluationContext().Add("targetingKey", "key").Add("key", "key"));
+            _converter.ToLdUser(EvaluationContext.Builder().Set("targetingKey", "key").Set("key", "key").Build());
             Assert.True(_logCapture.HasMessageWithText(LogLevel.Warn,
                 "The EvaluationContext contained both a 'targetingKey' and a 'key' attribute. The 'key'" +
                 "attribute will be discarded."));
@@ -108,10 +109,10 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
         [InlineData("anonymous", "bool")]
         public void ItLogsErrorsWhenTypesAreIncorrectForBuiltInAttributes(string attr, string type)
         {
-            var evaluationContext = new EvaluationContext();
-            evaluationContext.Add("targetingKey", "key");
-            //Number isn't valid for any built-in,
-            evaluationContext.Add(attr, 1);
+            var evaluationContext = EvaluationContext.Builder()
+                .Set("targetingKey", "key")
+                //Number isn't valid for any built-in,
+                .Set(attr, 1).Build();
 
             _converter.ToLdUser(evaluationContext);
 
@@ -125,9 +126,10 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
         {
             const string attributeKey = "some-custom-attribute";
             const string attributeValue = "the attribute value";
-            var evaluationContext = new EvaluationContext();
-            evaluationContext.Add("targetingKey", "the-key");
-            evaluationContext.Add(attributeKey, attributeValue);
+            var evaluationContext = EvaluationContext.Builder()
+                .Set("targetingKey", "the-key")
+                .Set(attributeKey, attributeValue)
+                .Build();
 
             var ldUser = _converter.ToLdUser(evaluationContext);
             Assert.Equal(
@@ -139,17 +141,19 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
         [Fact]
         public void ItCanUseKeyAttribute()
         {
-            var evaluationContext = new EvaluationContext();
-            evaluationContext.Add("key", "the-key");
+            var evaluationContext = EvaluationContext.Builder()
+                .Set("key", "the-key")
+                .Build();
             Assert.Equal("the-key", _converter.ToLdUser(evaluationContext).Key);
         }
 
         [Fact]
         public void ItUsesTheTargetingKeyInFavorOfKey()
         {
-            var evaluationContext = new EvaluationContext();
-            evaluationContext.Add("key", "key");
-            evaluationContext.Add("targetingKey", "targeting-key");
+            var evaluationContext = EvaluationContext.Builder()
+                .Set("key", "key")
+                .Set("targetingKey", "targeting-key")
+                .Build();
             Assert.Equal("targeting-key", _converter.ToLdUser(evaluationContext).Key);
         }
     }

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/LaunchDarkly.OpenFeature.ServerProvider.Tests.csproj
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/LaunchDarkly.OpenFeature.ServerProvider.Tests.csproj
@@ -32,13 +32,7 @@
         <PackageReference Include="LaunchDarkly.ServerSdk" Version="6.3.2" />
         <PackageReference Include="LaunchDarkly.TestHelpers" Version="1.3.0" />
         <PackageReference Include="Moq" Version="4.8.1" />
-<!--        <PackageReference Include="OpenFeature" Version="0.3.0" />-->
-    </ItemGroup>
-
-    <ItemGroup>
-        <Reference Include="OpenFeatureSDK">
-            <HintPath>..\..\..\..\open-feature/dotnet-sdk/src/OpenFeatureSDK/bin/Debug/netstandard2.0/OpenFeatureSDK.dll</HintPath>
-        </Reference>
+        <PackageReference Include="OpenFeature" Version="0.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/LaunchDarkly.OpenFeature.ServerProvider.Tests.csproj
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/LaunchDarkly.OpenFeature.ServerProvider.Tests.csproj
@@ -32,7 +32,13 @@
         <PackageReference Include="LaunchDarkly.ServerSdk" Version="6.3.2" />
         <PackageReference Include="LaunchDarkly.TestHelpers" Version="1.3.0" />
         <PackageReference Include="Moq" Version="4.8.1" />
-        <PackageReference Include="OpenFeature" Version="0.3.0" />
+<!--        <PackageReference Include="OpenFeature" Version="0.3.0" />-->
+    </ItemGroup>
+
+    <ItemGroup>
+        <Reference Include="OpenFeatureSDK">
+            <HintPath>..\..\..\..\open-feature/dotnet-sdk/src/OpenFeatureSDK/bin/Debug/netstandard2.0/OpenFeatureSDK.dll</HintPath>
+        </Reference>
     </ItemGroup>
 
     <ItemGroup>

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ProviderTests.cs
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ProviderTests.cs
@@ -33,9 +33,10 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
             ).Build());
 
             // This context is malformed and will cause a log.
-            var evaluationContext = new EvaluationContext();
-            evaluationContext.Add("targetingKey", "the-key");
-            evaluationContext.Add("key", "the-key");
+            var evaluationContext = EvaluationContext.Builder()
+                .Set("targetingKey", "the-key")
+                .Set("key", "the-key")
+                .Build();
 
             provider.ResolveBooleanValue("the-flag", false, evaluationContext);
             Assert.True(logCapture.HasMessageWithText(LogLevel.Warn,
@@ -55,9 +56,10 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
             ).Build());
 
             // This context is malformed and will cause a log.
-            var evaluationContext = new EvaluationContext();
-            evaluationContext.Add("targetingKey", "the-key");
-            evaluationContext.Add("key", "the-key");
+            var evaluationContext = EvaluationContext.Builder()
+                .Set("targetingKey", "the-key")
+                .Set("key", "the-key")
+                .Build();
 
             provider.ResolveBooleanValue("the-flag", false, evaluationContext);
 
@@ -67,8 +69,9 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
         [Fact]
         public void ItCanDoABooleanEvaluation()
         {
-            var evaluationContext = new EvaluationContext();
-            evaluationContext.Add("targetingKey", "the-key");
+            var evaluationContext = EvaluationContext.Builder()
+                .Set("targetingKey", "the-key")
+                .Build();
             var mock = new Mock<ILdClient>();
             mock.Setup(l => l.BoolVariationDetail("flag-key",
                     _converter.ToLdUser(evaluationContext), false))
@@ -82,8 +85,9 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
         [Fact]
         public void ItCanDoAStringEvaluation()
         {
-            var evaluationContext = new EvaluationContext();
-            evaluationContext.Add("targetingKey", "the-key");
+            var evaluationContext = EvaluationContext.Builder()
+                .Set("targetingKey", "the-key")
+                .Build();
             var mock = new Mock<ILdClient>();
             mock.Setup(l => l.StringVariationDetail("flag-key",
                     _converter.ToLdUser(evaluationContext), "default"))
@@ -97,8 +101,9 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
         [Fact]
         public void ItCanDoAnIntegerEvaluation()
         {
-            var evaluationContext = new EvaluationContext();
-            evaluationContext.Add("targetingKey", "the-key");
+            var evaluationContext = EvaluationContext.Builder()
+                .Set("targetingKey", "the-key")
+                .Build();
             var mock = new Mock<ILdClient>();
             mock.Setup(l => l.IntVariationDetail("flag-key",
                     _converter.ToLdUser(evaluationContext), 0))
@@ -112,8 +117,9 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
         [Fact]
         public void ItCanDoADoubleEvaluation()
         {
-            var evaluationContext = new EvaluationContext();
-            evaluationContext.Add("targetingKey", "the-key");
+            var evaluationContext = EvaluationContext.Builder()
+                .Set("targetingKey", "the-key")
+                .Build();
             var mock = new Mock<ILdClient>();
             mock.Setup(l => l.DoubleVariationDetail("flag-key",
                     _converter.ToLdUser(evaluationContext), 0))
@@ -127,8 +133,9 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
         [Fact]
         public void ItCanDoAValueEvaluation()
         {
-            var evaluationContext = new EvaluationContext();
-            evaluationContext.Add("targetingKey", "the-key");
+            var evaluationContext = EvaluationContext.Builder()
+                .Set("targetingKey", "the-key")
+                .Build();
             var mock = new Mock<ILdClient>();
             mock.Setup(l => l.JsonVariationDetail("flag-key",
                     It.IsAny<User>(), It.IsAny<LdValue>()))

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ValueExtensionsTests.cs
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ValueExtensionsTests.cs
@@ -82,18 +82,18 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
         [Fact]
         public void ItCanConvertStructures()
         {
-            var ofStructure = new Structure
-            {
-                {"true", true},
-                {"number", 42},
-                {"string", "string"}
-            };
-            var secondStructure = new Structure
-            {
-                {"number", 84},
-                {"string", "another-string"}
-            };
-            ofStructure.Add("structure", secondStructure);
+            var secondStructure = Structure.Builder()
+                .Set("number", 84)
+                .Set("string", "another-string")
+                .Build();
+
+            var ofStructure = Structure.Builder()
+                .Set("true", true)
+                .Set("number", 42)
+                .Set("string", "string")
+                .Set("structure", secondStructure)
+                .Build();
+
             var ofValue = new Value(ofStructure);
             var value = ofValue.ToLdValue();
 


### PR DESCRIPTION
Update to version `0.4.0` of the OpenFeature dotnet-sdk.
This version introduced builders as well as improved thread safety.

Updates are mostly for building contexts in tests. Additionally `structure` types are immutable now, so those are created with a builder when converting `object` return values.
