### PR TITLE
Remove strong naming.

### DIFF
--- a/src/LaunchDarkly.OpenFeature.ServerProvider/LaunchDarkly.OpenFeature.ServerProvider.csproj
+++ b/src/LaunchDarkly.OpenFeature.ServerProvider/LaunchDarkly.OpenFeature.ServerProvider.csproj
@@ -42,11 +42,6 @@
     <PackageReference Include="OpenFeature" Version="0.3.0" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'=='Release'">
-    <AssemblyOriginatorKeyFile>../../LaunchDarkly.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-  </PropertyGroup>
-
   <PropertyGroup>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LaunchDarkly.OpenFeature.ServerProvider.xml</DocumentationFile>
   </PropertyGroup>


### PR DESCRIPTION
The OpenFeatureSDK is not strong named, so we should not strong name ours.
If it becomes strongly named in the future, then we can start using strong names at that point.
