### PR TITLE
feat!: absorb breaking SDK changes

### DIFF
--- a/src/LaunchDarkly.OpenFeature.ServerProvider/EvalContextConverter.cs
+++ b/src/LaunchDarkly.OpenFeature.ServerProvider/EvalContextConverter.cs
@@ -1,7 +1,7 @@
 using System;
 using LaunchDarkly.Logging;
 using LaunchDarkly.Sdk;
-using OpenFeatureSDK.Model;
+using OpenFeature.Model;
 
 namespace LaunchDarkly.OpenFeature.ServerProvider
 {

--- a/src/LaunchDarkly.OpenFeature.ServerProvider/EvaluationDetailExtensions.cs
+++ b/src/LaunchDarkly.OpenFeature.ServerProvider/EvaluationDetailExtensions.cs
@@ -1,7 +1,7 @@
 using System;
 using LaunchDarkly.Sdk;
-using OpenFeatureSDK.Constant;
-using OpenFeatureSDK.Model;
+using OpenFeature.Constant;
+using OpenFeature.Model;
 
 namespace LaunchDarkly.OpenFeature.ServerProvider
 {

--- a/src/LaunchDarkly.OpenFeature.ServerProvider/LaunchDarkly.OpenFeature.ServerProvider.csproj
+++ b/src/LaunchDarkly.OpenFeature.ServerProvider/LaunchDarkly.OpenFeature.ServerProvider.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.ServerSdk" Version="[6.3.2,7.0)" />
-    <PackageReference Include="OpenFeature" Version="0.4.0" />
+    <PackageReference Include="OpenFeature" Version="0.5.0" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/LaunchDarkly.OpenFeature.ServerProvider/LdValueExtensions.cs
+++ b/src/LaunchDarkly.OpenFeature.ServerProvider/LdValueExtensions.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 using LaunchDarkly.Sdk;
-using OpenFeatureSDK.Model;
+using OpenFeature.Model;
 
 namespace LaunchDarkly.OpenFeature.ServerProvider
 {

--- a/src/LaunchDarkly.OpenFeature.ServerProvider/Provider.cs
+++ b/src/LaunchDarkly.OpenFeature.ServerProvider/Provider.cs
@@ -3,8 +3,8 @@ using LaunchDarkly.Logging;
 using LaunchDarkly.Sdk;
 using LaunchDarkly.Sdk.Server;
 using LaunchDarkly.Sdk.Server.Interfaces;
-using OpenFeatureSDK;
-using OpenFeatureSDK.Model;
+using OpenFeature;
+using OpenFeature.Model;
 
 namespace LaunchDarkly.OpenFeature.ServerProvider
 {
@@ -19,9 +19,9 @@ namespace LaunchDarkly.OpenFeature.ServerProvider
     ///     var ldClient  = new LdClient(config);
     ///     var provider = new Provider(ldClient);
     ///
-    ///     OpenFeatureSDK.OpenFeature.Instance.SetProvider(provider);
+    ///     OpenFeature.Api.Instance.SetProvider(provider);
     ///
-    ///     var client = OpenFeatureSDK.OpenFeature.Instance.GetClient();
+    ///     var client = OpenFeature.Api.Instance.GetClient();
     /// </example>
     public sealed class Provider : FeatureProvider
     {

--- a/src/LaunchDarkly.OpenFeature.ServerProvider/ValueExtensions.cs
+++ b/src/LaunchDarkly.OpenFeature.ServerProvider/ValueExtensions.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using System.Linq;
 using LaunchDarkly.Sdk;
-using OpenFeatureSDK.Model;
+using OpenFeature.Model;
 
 namespace LaunchDarkly.OpenFeature.ServerProvider
 {

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/BasicTypeTestData.cs
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/BasicTypeTestData.cs
@@ -1,7 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using LaunchDarkly.Sdk;
-using OpenFeatureSDK.Model;
+using OpenFeature.Model;
 
 namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
 {

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/EvalContextConverterTests.cs
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/EvalContextConverterTests.cs
@@ -1,7 +1,7 @@
 using LaunchDarkly.Logging;
 using LaunchDarkly.Sdk;
 using LaunchDarkly.Sdk.Server;
-using OpenFeatureSDK.Model;
+using OpenFeature.Model;
 using Xunit;
 
 namespace LaunchDarkly.OpenFeature.ServerProvider.Tests

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/EvaluationDetailExtensionsTest.cs
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/EvaluationDetailExtensionsTest.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using LaunchDarkly.Sdk;
-using OpenFeatureSDK.Constant;
-using OpenFeatureSDK.Model;
+using OpenFeature.Constant;
+using OpenFeature.Model;
 using Xunit;
 
 namespace LaunchDarkly.OpenFeature.ServerProvider.Tests

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/LaunchDarkly.OpenFeature.ServerProvider.Tests.csproj
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/LaunchDarkly.OpenFeature.ServerProvider.Tests.csproj
@@ -32,7 +32,7 @@
         <PackageReference Include="LaunchDarkly.ServerSdk" Version="6.3.2" />
         <PackageReference Include="LaunchDarkly.TestHelpers" Version="1.3.0" />
         <PackageReference Include="Moq" Version="4.8.1" />
-        <PackageReference Include="OpenFeature" Version="0.4.0" />
+        <PackageReference Include="OpenFeature" Version="0.5.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/LdValueExtensionsTests.cs
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/LdValueExtensionsTests.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using LaunchDarkly.Sdk;
-using OpenFeatureSDK.Model;
+using OpenFeature.Model;
 using Xunit;
 
 namespace LaunchDarkly.OpenFeature.ServerProvider.Tests

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ProviderTests.cs
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ProviderTests.cs
@@ -4,7 +4,7 @@ using LaunchDarkly.Sdk.Server;
 using LaunchDarkly.Sdk.Server.Integrations;
 using LaunchDarkly.Sdk.Server.Interfaces;
 using Moq;
-using OpenFeatureSDK.Model;
+using OpenFeature.Model;
 using Xunit;
 
 namespace LaunchDarkly.OpenFeature.ServerProvider.Tests

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ValueExtensionsTests.cs
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ValueExtensionsTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using LaunchDarkly.Sdk;
-using OpenFeatureSDK.Model;
+using OpenFeature.Model;
 using Xunit;
 
 namespace LaunchDarkly.OpenFeature.ServerProvider.Tests


### PR DESCRIPTION
Updates OpenFeature SDK to 0.5.0, which includes a change to the namespace and the API object (see: https://github.com/open-feature/dotnet-sdk/pull/82)

No functional changes.