### PR TITLE
Update readme and client version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ This version of the SDK is built for the following targets:
 ### Installation
 
 ```
-dotnet add LaunchDarkly.ServerSdk
-dotnet add LaunchDarkly.OpenFeature.ServerSdk
-dotnet add OpenFeature
+dotnet add package LaunchDarkly.ServerSdk
+dotnet add package LaunchDarkly.OpenFeature.ServerProvider
+dotnet add package OpenFeature
 ```
 
 ### Usage
@@ -41,7 +41,7 @@ var config = Configuration.Builder("my-sdk-key")
 var ldClient  = new LdClient(config);
 var provider = new Provider(ldClient);
 
-OpenFeature.SDK.OpenFeature.Instance.SetProvider(provider);
+OpenFeature.Api.Instance.SetProvider(provider);
 ```
 
 Refer to the [SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/node-js) for instructions on getting started with using the SDK.

--- a/src/LaunchDarkly.OpenFeature.ServerProvider/LaunchDarkly.OpenFeature.ServerProvider.csproj
+++ b/src/LaunchDarkly.OpenFeature.ServerProvider/LaunchDarkly.OpenFeature.ServerProvider.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.ServerSdk" Version="[6.3.2,7.0)" />
-    <PackageReference Include="OpenFeature" Version="0.5.0" />
+    <PackageReference Include="OpenFeature" Version="[1.0.0, 2.0.0)" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/LaunchDarkly.OpenFeature.ServerProvider.Tests.csproj
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/LaunchDarkly.OpenFeature.ServerProvider.Tests.csproj
@@ -32,7 +32,7 @@
         <PackageReference Include="LaunchDarkly.ServerSdk" Version="6.3.2" />
         <PackageReference Include="LaunchDarkly.TestHelpers" Version="1.3.0" />
         <PackageReference Include="Moq" Version="4.8.1" />
-        <PackageReference Include="OpenFeature" Version="[1.0.0, 2.0.0)" />
+        <PackageReference Include="OpenFeature" Version="1.*" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/LaunchDarkly.OpenFeature.ServerProvider.Tests.csproj
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/LaunchDarkly.OpenFeature.ServerProvider.Tests.csproj
@@ -32,7 +32,7 @@
         <PackageReference Include="LaunchDarkly.ServerSdk" Version="6.3.2" />
         <PackageReference Include="LaunchDarkly.TestHelpers" Version="1.3.0" />
         <PackageReference Include="Moq" Version="4.8.1" />
-        <PackageReference Include="OpenFeature" Version="0.5.0" />
+        <PackageReference Include="OpenFeature" Version="[1.0.0, 2.0.0)" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Update instructions with correct `dotnet add` arguments. Update the example for the latest API usage.
Move to 1.0.0 or newer version of the client.