### PR TITLE
feat: Add support for Tracking API

### DIFF
--- a/src/LaunchDarkly.OpenFeature.ServerProvider/LaunchDarkly.OpenFeature.ServerProvider.csproj
+++ b/src/LaunchDarkly.OpenFeature.ServerProvider/LaunchDarkly.OpenFeature.ServerProvider.csproj
@@ -41,7 +41,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.ServerSdk" Version="[8.1.0,9.0)" />
-    <PackageReference Include="OpenFeature" Version="[2.0.0, 3.0.0)" />
+    <PackageReference Include="OpenFeature" Version="[2.2.0, 3.0.0)" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/LaunchDarkly.OpenFeature.ServerProvider/Provider.cs
+++ b/src/LaunchDarkly.OpenFeature.ServerProvider/Provider.cs
@@ -183,7 +183,7 @@ namespace LaunchDarkly.OpenFeature.ServerProvider
                 {
                     ProviderName = _metadata.Name,
                     Type = ProviderEventTypes.ProviderConfigurationChanged,
-                    FlagsChanged = new List<string> {changeEvent.Key},
+                    FlagsChanged = new List<string> { changeEvent.Key },
                 }).ConfigureAwait(false);
             }
             catch (Exception e)
@@ -215,6 +215,25 @@ namespace LaunchDarkly.OpenFeature.ServerProvider
                     _statusProvider.SetStatus(ProviderStatus.Fatal, ProviderShutdownMessage);
                     _initCompletion.TrySetException(new LaunchDarklyProviderInitException(ProviderShutdownMessage));
                     break;
+            }
+        }
+
+        /// <inheritdoc />
+        public override void Track(string trackingEventName, EvaluationContext evaluationContext = null, TrackingEventDetails trackingEventDetails = default)
+        {
+            var (value, details) = trackingEventDetails.ToLdValue();
+
+            if (value.HasValue)
+            {
+                _client.Track(trackingEventName, _contextConverter.ToLdContext(evaluationContext), details, value.Value);
+            }
+            else if (details.Type != LdValueType.Null)
+            {
+                _client.Track(trackingEventName, _contextConverter.ToLdContext(evaluationContext), details);
+            }
+            else
+            {
+                _client.Track(trackingEventName, _contextConverter.ToLdContext(evaluationContext));
             }
         }
     }

--- a/src/LaunchDarkly.OpenFeature.ServerProvider/TrackingEventDetailsExtensions.cs
+++ b/src/LaunchDarkly.OpenFeature.ServerProvider/TrackingEventDetailsExtensions.cs
@@ -1,0 +1,39 @@
+using LaunchDarkly.Sdk;
+using OpenFeature.Model;
+
+namespace LaunchDarkly.OpenFeature.ServerProvider
+{
+    internal static class TrackingEventDetailsExtensions
+    {
+        /// <summary>
+        /// Extract an OpenFeature <see cref="TrackingEventDetails"/> into an <see cref="LdValue"/>.
+        /// </summary>
+        /// <param name="trackingEventDetails">The value to extract</param>
+        public static (double?, LdValue) ToLdValue(this TrackingEventDetails trackingEventDetails)
+        {
+            if (trackingEventDetails == null)
+            {
+                return (null, LdValue.Null);
+            }
+
+            var value = trackingEventDetails.Value;
+
+            LdValue details;
+            if (trackingEventDetails.Count == 0)
+            {
+                details = LdValue.Null;
+            }
+            else
+            {
+                var builder = LdValue.BuildObject();
+                foreach (var keyvalue in trackingEventDetails)
+                {
+                    builder.Add(keyvalue.Key, keyvalue.Value.ToLdValue());
+                }
+                details = builder.Build();
+            }
+
+            return (value, details);
+        }
+    }
+}

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/LaunchDarkly.OpenFeature.ServerProvider.Tests.csproj
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/LaunchDarkly.OpenFeature.ServerProvider.Tests.csproj
@@ -32,7 +32,7 @@
         <PackageReference Include="LaunchDarkly.ServerSdk" Version="8.5.1" />
         <PackageReference Include="LaunchDarkly.TestHelpers" Version="2.0.0" />
         <PackageReference Include="Moq" Version="4.8.1" />
-        <PackageReference Include="OpenFeature" Version="2.0.0" />
+        <PackageReference Include="OpenFeature" Version="2.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ProviderTests.cs
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ProviderTests.cs
@@ -272,5 +272,73 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
             Assert.Single(eventPayloadB?.FlagsChanged ?? new List<string>());
             Assert.NotEqual(eventPayloadA?.FlagsChanged[0], eventPayloadB?.FlagsChanged[0]);
         }
+
+        [Fact(Timeout = 5000)]
+        public void ItTracksCustomEvents()
+        {
+            var evaluationContext = EvaluationContext.Builder()
+                .Set("targetingKey", "the-key")
+                .Build();
+            var mock = new Mock<ILdClient>();
+            mock.Setup(l => l.GetLogger())
+                .Returns(Components.NoLogging.Build(null).LogAdapter.Logger(null));
+            mock.Setup(l => l.Track("event-key-123abc", _converter.ToLdContext(evaluationContext))).Verifiable();
+            var provider = new Provider(mock.Object);
+
+            provider.Track("event-key-123abc", evaluationContext);
+
+            mock.Verify();
+        }
+
+        [Fact(Timeout = 5000)]
+        public void ItTracksCustomEventsWithValue()
+        {
+            var evaluationContext = EvaluationContext.Builder()
+                .Set("targetingKey", "the-key")
+                .Build();
+            var mock = new Mock<ILdClient>();
+            mock.Setup(l => l.GetLogger())
+                .Returns(Components.NoLogging.Build(null).LogAdapter.Logger(null));
+            mock.Setup(l => l.Track("event-key-123abc", _converter.ToLdContext(evaluationContext), LdValue.Null, 99.77)).Verifiable();
+            var provider = new Provider(mock.Object);
+
+            provider.Track("event-key-123abc", evaluationContext, TrackingEventDetails.Builder().SetValue(99.77).Build());
+
+            mock.Verify();
+        }
+
+        [Fact(Timeout = 5000)]
+        public void ItTracksCustomEventsWithDetails()
+        {
+            var evaluationContext = EvaluationContext.Builder()
+                .Set("targetingKey", "the-key")
+                .Build();
+            var mock = new Mock<ILdClient>();
+            mock.Setup(l => l.GetLogger())
+                .Returns(Components.NoLogging.Build(null).LogAdapter.Logger(null));
+            mock.Setup(l => l.Track("event-key-123abc", _converter.ToLdContext(evaluationContext), LdValue.BuildObject().Set("color", "red").Build())).Verifiable();
+            var provider = new Provider(mock.Object);
+
+            provider.Track("event-key-123abc", evaluationContext, TrackingEventDetails.Builder().Set("color", "red").Build());
+
+            mock.Verify();
+        }
+
+        [Fact(Timeout = 5000)]
+        public void ItTracksCustomEventsWithDetailsAndValue()
+        {
+            var evaluationContext = EvaluationContext.Builder()
+                .Set("targetingKey", "the-key")
+                .Build();
+            var mock = new Mock<ILdClient>();
+            mock.Setup(l => l.GetLogger())
+                .Returns(Components.NoLogging.Build(null).LogAdapter.Logger(null));
+            mock.Setup(l => l.Track("event-key-123abc", _converter.ToLdContext(evaluationContext), LdValue.BuildObject().Set("currency", "USD").Build(), 99.77)).Verifiable();
+            var provider = new Provider(mock.Object);
+
+            provider.Track("event-key-123abc", evaluationContext, TrackingEventDetails.Builder().SetValue(99.77).Set("currency", "USD").Build());
+
+            mock.Verify();
+        }
     }
 }

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/TrackingEventDetailsExtensionsTest.cs
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/TrackingEventDetailsExtensionsTest.cs
@@ -1,0 +1,56 @@
+using LaunchDarkly.Sdk;
+using OpenFeature.Model;
+using Xunit;
+
+namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
+{
+    public class TrackingEventDetailsExtensionsTest
+    {
+        [Fact]
+        public void ItCanHandleValuesAndDetails()
+        {
+            var trackingEventDetails = TrackingEventDetails.Builder().SetValue(99.77).Set("currency", "USD").Build();
+            var (value, details) = trackingEventDetails.ToLdValue();
+            Assert.Equal(LdValueType.Object, details.Type);
+            Assert.Equal(LdValue.Of("USD"), details.Get("currency"));
+            Assert.Equal(99.77, value);
+        }
+
+        [Fact]
+        public void ItCanHandleDetailsOnly()
+        {
+            var trackingEventDetails = TrackingEventDetails.Builder().Set("color", "red").Build();
+            var (value, details) = trackingEventDetails.ToLdValue();
+            Assert.Equal(LdValueType.Object, details.Type);
+            Assert.Equal(LdValue.Of("red"), details.Get("color"));
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void ItCanHandleValuesOnly()
+        {
+            var trackingEventDetails = TrackingEventDetails.Builder().SetValue(99.77).Build();
+            var (value, details) = trackingEventDetails.ToLdValue();
+            Assert.Equal(LdValueType.Null, details.Type);
+            Assert.Equal(99.77, value);
+        }
+
+        [Fact]
+        public void ItCanHandleEmptyStructures()
+        {
+            var trackingEventDetails = TrackingEventDetails.Empty;
+            var (value, details) = trackingEventDetails.ToLdValue();
+            Assert.Equal(LdValueType.Null, details.Type);
+            Assert.Null(value);
+        }
+
+        [Fact]
+        public void ItCanHandleNull()
+        {
+            TrackingEventDetails trackingEventDetails = null;
+            var (value, details) = trackingEventDetails.ToLdValue();
+            Assert.Equal(LdValueType.Null, details.Type);
+            Assert.Null(value);
+        }
+    }
+}


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

The Tracking API has been part of the OpenFeature since version 2.2.0.

LaunchDarkly has an API for receiving [custom events](https://launchdarkly.com/docs/sdk/features/events), which is used by their Experiments and Guarded Rollout modules.

**Describe the solution you've provided**

Add a `Track` method the provider, which translates the OpenFeature values into LaunchDarkly values.

**Describe alternatives you've considered**

Using the LaunchDarkly client directly, which defeats the whole purpose of using OpenFeature.

**Additional context**

Should probably update the README.md to state it supports tracking.

BEGIN_COMMIT_OVERRIDE
feat: Add support for Tracking API 
feat: Bump minimum OpenFeature SDK version to 2.2.
END_COMMIT_OVERRIDE