### PR TITLE
ci: add permissions to publish caller job and upgrade release-please-action to v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
 
     steps:
-      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -26,6 +26,9 @@ jobs:
 
   call-workflow-publish:
     needs: release-please
+    permissions:
+      id-token: write
+      contents: write
     uses: ./.github/workflows/publish.yml
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
     with:


### PR DESCRIPTION
## Summary
Fixes Release Please `startup_failure` by adding explicit `permissions` to the `call-workflow-publish` caller job. Also upgrades release-please-action from v4 to v5.

## Review & Testing Checklist for Human
- [ ] Verify the release-please workflow runs without startup_failure on next push to main

### Notes
Same fix pattern as dotnet-core PR #241. The publish caller job needs explicit permissions because publish.yml declares permissions that exceed the restricted org defaults.

Link to Devin session: https://app.devin.ai/sessions/54e32482848742c19ebf9c374efdc833
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; main risk is workflow permission scoping or action version upgrade affecting release/publish automation behavior.
> 
> **Overview**
> Upgrades `googleapis/release-please-action` from v4.4.0 to v5.0.0 in `.github/workflows/release-please.yml`.
> 
> Adds explicit `permissions` (`id-token: write`, `contents: write`) to the `call-workflow-publish` reusable-workflow caller job so the publish workflow can run with the required token scopes when a release is created.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29e374c5e410159c3e0a9fcf8773ebe3d0f582fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->