### PR TITLE
fix: Do not report a permanent data source failure as fatal

### DIFF
--- a/src/LaunchDarkly.OpenFeature.ServerProvider/Provider.cs
+++ b/src/LaunchDarkly.OpenFeature.ServerProvider/Provider.cs
@@ -214,9 +214,9 @@ namespace LaunchDarkly.OpenFeature.ServerProvider
                     break;
                 case DataSourceState.Off:
                 default:
-                    // If we had initialized every, then we could still initialize flags, but I think we need to let
-                    // a consumer know we have encountered an unrecoverable problem with the connection.
-                    _statusProvider.SetStatus(ProviderStatus.Fatal, ProviderShutdownMessage);
+                    // The status is an error, and not fatal, because the LaunchDarkly client can continue to
+                    // evaluate flags using the data it already has.
+                    _statusProvider.SetStatus(ProviderStatus.Error, ProviderShutdownMessage);
                     _initCompletion.TrySetException(new LaunchDarklyProviderInitException(ProviderShutdownMessage));
                     break;
             }

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ClientIntegrationTests.cs
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ClientIntegrationTests.cs
@@ -119,6 +119,39 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
             Thread.Sleep(100);
             Assert.Equal(1, errorCount);
         }
+
+        [Fact(Timeout = 5000)]
+        public async Task ItCanEvaluateFlagsAfterTheDataSourceHasBeenShutdown()
+        {
+            var mockClient = new Mock<ILdClient>();
+            mockClient.Setup(l => l.GetLogger())
+                .Returns(Components.NoLogging.Build(null).LogAdapter.Logger(null));
+            mockClient.Setup(l => l.Initialized).Returns(true);
+            mockClient.Setup(l => l.BoolVariationDetail("the-flag", It.IsAny<Sdk.Context>(), false))
+                .Returns(new Sdk.EvaluationDetail<bool>(true, 10, Sdk.EvaluationReason.FallthroughReason));
+
+            var mockDataSourceStatus = new Mock<IDataSourceStatusProvider>();
+            mockDataSourceStatus.Setup(l => l.Status).Returns(new DataSourceStatus
+            {
+                State = DataSourceState.Valid
+            });
+            mockClient.Setup(l => l.DataSourceStatusProvider).Returns(mockDataSourceStatus.Object);
+
+            var mockFlagTracker = new Mock<IFlagTracker>();
+            mockClient.Setup(l => l.FlagTracker).Returns(mockFlagTracker.Object);
+
+            var provider = new Provider(mockClient.Object);
+            await Api.Instance.SetProviderAsync(provider);
+
+            mockDataSourceStatus.Raise(e => e.StatusChanged += null,
+                mockDataSourceStatus.Object,
+                new DataSourceStatus { State = DataSourceState.Off });
+            Thread.Sleep(100);
+
+            var client = Api.Instance.GetClient();
+            Assert.True(await client.GetBooleanValueAsync("the-flag", false,
+                EvaluationContext.Builder().Set("targetingKey", "the-key").Build()));
+        }
 #endif
     }
 }


### PR DESCRIPTION
A permanently shut down data source set the provider's internal status to `Fatal`, even though the LaunchDarkly client can keep evaluating flags from the data it already has.

- `DataSourceState.Off` now sets `ProviderStatus.Error`, matching `InitializeAsync` and the Java provider
- No user-visible change today: both `Error` and `Fatal` emit `ProviderEventTypes.ProviderError`, and the OpenFeature SDK derives provider status from events, so nothing consumed the `Fatal` value
- Adds an integration test asserting evaluations still succeed through the OpenFeature client after the data source goes off

@cursor review

<details>
<summary>Implementation details</summary>

**Why change it if nothing consumes it**

`Fatal` is the OpenFeature status that means "flag resolution cannot happen"; the SDK short-circuits to call-site defaults in that state. That is wrong for LaunchDarkly, since a dead stream (for example a 401 on an established connection) leaves the in-memory store fully usable. The value was only saved from causing that behavior because `StatusProvider` maps both `Error` and `Fatal` to a `ProviderError` event. Leaving the misleading value in place invites a regression the next time this status is wired to anything.

The sibling fix in the Python provider (launchdarkly/openfeature-python-server#52) does have user-visible impact, because that provider emits a fatal event directly.

**Alternatives considered**

Emitting `Stale` for `Off` was rejected: the failure is not recoverable without a new client, so consumers should see an error.

**Testing**

`dotnet test test/LaunchDarkly.OpenFeature.ServerProvider.Tests -f net8.0` — 60 tests pass, including the new `ItCanEvaluateFlagsAfterTheDataSourceHasBeenShutdown`. Note that this test also passes on `main`, for the event-mapping reason above; it is a guard, not a reproduction.

No visual preview applies — this is a server-side provider change.

</details>


Link to Devin session: https://app.devin.ai/sessions/0c452d209ec54b068ba120b4c92b8f6c
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> When the LaunchDarkly data source shuts down permanently (`DataSourceState.Off`), the provider now reports **`ProviderStatus.Error`** instead of **`ProviderStatus.Fatal`**, because the LD client can still evaluate flags from in-memory data.
> 
> This aligns `StatusChangeHandler` with **`InitializeAsync`** (which already used `Error` for `Off`) and with the Java provider. **`StatusProvider`** still maps both `Error` and `Fatal` to `ProviderEventTypes.ProviderError`, so emitted events are unchanged today; the fix avoids mislabeling the internal status if OpenFeature later treats `Fatal` as “cannot resolve flags.”
> 
> A new integration test **`ItCanEvaluateFlagsAfterTheDataSourceHasBeenShutdown`** verifies boolean evaluation through the OpenFeature client after the mocked data source transitions to `Off`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbe6159ab6768051e6b02d02a32090b73356c179. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->