### PR TITLE
feat: Stop waiting for initialization after the configured start wait time

### DIFF
--- a/src/LaunchDarkly.OpenFeature.ServerProvider/Provider.cs
+++ b/src/LaunchDarkly.OpenFeature.ServerProvider/Provider.cs
@@ -41,8 +41,11 @@ namespace LaunchDarkly.OpenFeature.ServerProvider
         private const string ProviderShutdownMessage =
             "the provider has encountered a permanent error or been shutdown";
 
-        internal Provider(ILdClient client)
+        private readonly TimeSpan? _initTimeout;
+
+        internal Provider(ILdClient client, TimeSpan? initTimeout = null)
         {
+            _initTimeout = initTimeout;
             _client = client;
             _logger = _client.GetLogger().SubLogger(NameSpace);
             _statusProvider = new StatusProvider(EventChannel, _metadata.Name, _logger);
@@ -53,7 +56,7 @@ namespace LaunchDarkly.OpenFeature.ServerProvider
         ///  Construct a new instance of the provider with the given configuration.
         /// </summary>
         /// <param name="config">A client configuration object</param>
-        public Provider(Configuration config) : this(new LdClient(WrapConfig(config)))
+        public Provider(Configuration config) : this(new LdClient(WrapConfig(config)), config.StartWaitTime)
         {
         }
 
@@ -61,7 +64,7 @@ namespace LaunchDarkly.OpenFeature.ServerProvider
         ///  Construct a new instance of the provider with the given SDK key.
         /// </summary>
         /// <param name="sdkKey">The SDK key</param>
-        public Provider(string sdkKey) : this(new LdClient(WrapConfig(Configuration.Builder(sdkKey).Build())))
+        public Provider(string sdkKey) : this(Configuration.Builder(sdkKey).Build())
         {
         }
 
@@ -159,6 +162,11 @@ namespace LaunchDarkly.OpenFeature.ServerProvider
                 _initCompletion.TrySetException(new LaunchDarklyProviderInitException(ProviderShutdownMessage));
             }
 
+            if (_initTimeout.HasValue && !_initCompletion.Task.IsCompleted)
+            {
+                ScheduleInitTimeout(_initTimeout.Value);
+            }
+
             return _initCompletion.Task;
         }
 
@@ -173,6 +181,23 @@ namespace LaunchDarkly.OpenFeature.ServerProvider
         }
 
         #endregion
+
+        private void ScheduleInitTimeout(TimeSpan timeout)
+        {
+            var message = $"the provider did not become ready within {timeout.TotalMilliseconds}ms";
+            Task.Delay(timeout < TimeSpan.Zero ? TimeSpan.Zero : timeout).ContinueWith(_ =>
+            {
+                if (_initCompletion.Task.IsCompleted)
+                {
+                    return;
+                }
+
+                _logger.Warn(message);
+                // The client keeps trying to connect, so a later successful connection will emit a ready event.
+                _statusProvider.SetStatus(ProviderStatus.Error, message);
+                _initCompletion.TrySetException(new LaunchDarklyProviderInitException(message));
+            }).ConfigureAwait(false);
+        }
 
         private void FlagChangeHandler(object sender, FlagChangeEvent changeEvent)
         {

--- a/src/LaunchDarkly.OpenFeature.ServerProvider/Provider.cs
+++ b/src/LaunchDarkly.OpenFeature.ServerProvider/Provider.cs
@@ -56,7 +56,7 @@ namespace LaunchDarkly.OpenFeature.ServerProvider
         ///  Construct a new instance of the provider with the given configuration.
         /// </summary>
         /// <param name="config">A client configuration object</param>
-        public Provider(Configuration config) : this(new LdClient(WrapConfig(config)), config.StartWaitTime)
+        public Provider(Configuration config) : this(new LdClient(WrapConfig(config)), InitTimeout(config))
         {
         }
 
@@ -182,20 +182,30 @@ namespace LaunchDarkly.OpenFeature.ServerProvider
 
         #endregion
 
+        /// <summary>
+        /// A start wait time of zero means the caller does not want to block on initialization at all, so the provider
+        /// waits indefinitely and leaves it to the caller to decide how long to wait.
+        /// </summary>
+        private static TimeSpan? InitTimeout(Configuration config) =>
+            config.StartWaitTime > TimeSpan.Zero ? config.StartWaitTime : (TimeSpan?)null;
+
         private void ScheduleInitTimeout(TimeSpan timeout)
         {
             var message = $"the provider did not become ready within {timeout.TotalMilliseconds}ms";
-            Task.Delay(timeout < TimeSpan.Zero ? TimeSpan.Zero : timeout).ContinueWith(_ =>
+            Task.Delay(timeout).ContinueWith(_ =>
             {
-                if (_initCompletion.Task.IsCompleted)
+                lock (_initLock)
                 {
-                    return;
-                }
+                    if (_initCompletion.Task.IsCompleted)
+                    {
+                        return;
+                    }
 
-                _logger.Warn(message);
-                // The client keeps trying to connect, so a later successful connection will emit a ready event.
-                _statusProvider.SetStatus(ProviderStatus.Error, message);
-                _initCompletion.TrySetException(new LaunchDarklyProviderInitException(message));
+                    _logger.Warn(message);
+                    // The client keeps trying to connect, so a later successful connection will emit a ready event.
+                    _statusProvider.SetStatus(ProviderStatus.Error, message);
+                    _initCompletion.TrySetException(new LaunchDarklyProviderInitException(message));
+                }
             }).ConfigureAwait(false);
         }
 
@@ -228,8 +238,11 @@ namespace LaunchDarkly.OpenFeature.ServerProvider
                 case DataSourceState.Initializing:
                     break;
                 case DataSourceState.Valid:
-                    _statusProvider.SetStatus(ProviderStatus.Ready);
-                    _initCompletion.TrySetResult(true);
+                    lock (_initLock)
+                    {
+                        _statusProvider.SetStatus(ProviderStatus.Ready);
+                        _initCompletion.TrySetResult(true);
+                    }
                     break;
                 case DataSourceState.Interrupted:
                     // The "ProviderStatus.Error" state says it is unable to evaluate flags. We can always evaluate

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ClientIntegrationTests.cs
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ClientIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using LaunchDarkly.Logging;
@@ -151,6 +152,43 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
             var client = Api.Instance.GetClient();
             Assert.True(await client.GetBooleanValueAsync("the-flag", false,
                 EvaluationContext.Builder().Set("targetingKey", "the-key").Build()));
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task ItBecomesReadyAfterInitializationTimesOut()
+        {
+            var mockClient = new Mock<ILdClient>();
+            mockClient.Setup(l => l.GetLogger())
+                .Returns(Components.NoLogging.Build(null).LogAdapter.Logger(null));
+
+            var mockDataSourceStatus = new Mock<IDataSourceStatusProvider>();
+            mockDataSourceStatus.Setup(l => l.Status).Returns(new DataSourceStatus
+            {
+                State = DataSourceState.Initializing
+            });
+            mockClient.Setup(l => l.DataSourceStatusProvider).Returns(mockDataSourceStatus.Object);
+
+            var mockFlagTracker = new Mock<IFlagTracker>();
+            mockClient.Setup(l => l.FlagTracker).Returns(mockFlagTracker.Object);
+
+            var provider = new Provider(mockClient.Object, TimeSpan.FromMilliseconds(50));
+
+            await Api.Instance.SetProviderAsync(provider);
+
+            // The handler is added after the failed initialization, otherwise it would be immediately invoked for
+            // the state of any previously registered provider.
+            var readyCount = 0;
+            Api.Instance.AddHandler(ProviderEventTypes.ProviderReady,
+                details => { Interlocked.Increment(ref readyCount); });
+
+            mockDataSourceStatus.Raise(e => e.StatusChanged += null,
+                mockDataSourceStatus.Object,
+                new DataSourceStatus { State = DataSourceState.Valid });
+
+            // The initialization timeout does not stop the client from connecting, so a later connection makes the
+            // provider ready.
+            Thread.Sleep(100);
+            Assert.Equal(1, readyCount);
         }
 #endif
     }

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ClientIntegrationTests.cs
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ClientIntegrationTests.cs
@@ -160,6 +160,8 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
             var mockClient = new Mock<ILdClient>();
             mockClient.Setup(l => l.GetLogger())
                 .Returns(Components.NoLogging.Build(null).LogAdapter.Logger(null));
+            mockClient.Setup(l => l.BoolVariationDetail("the-flag", It.IsAny<Sdk.Context>(), false))
+                .Returns(new Sdk.EvaluationDetail<bool>(true, 10, Sdk.EvaluationReason.FallthroughReason));
 
             var mockDataSourceStatus = new Mock<IDataSourceStatusProvider>();
             mockDataSourceStatus.Setup(l => l.Status).Returns(new DataSourceStatus
@@ -181,6 +183,11 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
             Api.Instance.AddHandler(ProviderEventTypes.ProviderReady,
                 details => { Interlocked.Increment(ref readyCount); });
 
+            var context = EvaluationContext.Builder().Set("targetingKey", "the-key").Build();
+
+            // A timed out initialization does not short-circuit evaluations.
+            Assert.True(await Api.Instance.GetClient().GetBooleanValueAsync("the-flag", false, context));
+
             mockDataSourceStatus.Raise(e => e.StatusChanged += null,
                 mockDataSourceStatus.Object,
                 new DataSourceStatus { State = DataSourceState.Valid });
@@ -189,6 +196,7 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
             // provider ready.
             Thread.Sleep(100);
             Assert.Equal(1, readyCount);
+            Assert.True(await Api.Instance.GetClient().GetBooleanValueAsync("the-flag", false, context));
         }
 #endif
     }

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ProviderTests.cs
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ProviderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Timers;
@@ -127,6 +128,63 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
                 await Record.ExceptionAsync(async () => await provider.InitializeAsync(EvaluationContext.Empty));
             Assert.NotNull(exception);
             Assert.Equal("the provider has encountered a permanent error or been shutdown", exception.Message);
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task ItStopsWaitingForInitializationAfterTheStartWaitTime()
+        {
+            var mockClient = new Mock<ILdClient>();
+            mockClient.Setup(l => l.GetLogger())
+                .Returns(Components.NoLogging.Build(null).LogAdapter.Logger(null));
+
+            var mockDataSourceStatus = new Mock<IDataSourceStatusProvider>();
+            mockDataSourceStatus.Setup(l => l.Status).Returns(new DataSourceStatus
+            {
+                State = DataSourceState.Initializing
+            });
+            mockClient.Setup(l => l.DataSourceStatusProvider).Returns(mockDataSourceStatus.Object);
+
+            var mockFlagTracker = new Mock<IFlagTracker>();
+            mockClient.Setup(l => l.FlagTracker).Returns(mockFlagTracker.Object);
+
+            var provider = new Provider(mockClient.Object, TimeSpan.FromMilliseconds(50));
+
+            var exception =
+                await Record.ExceptionAsync(async () => await provider.InitializeAsync(EvaluationContext.Empty));
+            Assert.NotNull(exception);
+            Assert.Equal("the provider did not become ready within 50ms", exception.Message);
+        }
+
+        [Fact(Timeout = 5000)]
+        public async Task ItDoesNotTimeOutInitializationWhenTheClientBecomesReady()
+        {
+            var mockClient = new Mock<ILdClient>();
+            mockClient.Setup(l => l.GetLogger())
+                .Returns(Components.NoLogging.Build(null).LogAdapter.Logger(null));
+
+            var mockDataSourceStatus = new Mock<IDataSourceStatusProvider>();
+            mockDataSourceStatus.Setup(l => l.Status).Returns(new DataSourceStatus
+            {
+                State = DataSourceState.Initializing
+            });
+            mockClient.Setup(l => l.DataSourceStatusProvider).Returns(mockDataSourceStatus.Object);
+
+            var mockFlagTracker = new Mock<IFlagTracker>();
+            mockClient.Setup(l => l.FlagTracker).Returns(mockFlagTracker.Object);
+
+            var provider = new Provider(mockClient.Object, TimeSpan.FromMilliseconds(2000));
+
+            var completionTimer = new Timer(50);
+            completionTimer.AutoReset = false;
+            completionTimer.Elapsed += (sender, args) =>
+            {
+                mockDataSourceStatus.Raise(e => e.StatusChanged += null,
+                    mockDataSourceStatus.Object,
+                    new DataSourceStatus {State = DataSourceState.Valid});
+            };
+            completionTimer.Start();
+
+            await provider.InitializeAsync(EvaluationContext.Empty);
         }
 
         [Fact(Timeout = 5000)]

--- a/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ProviderTests.cs
+++ b/test/LaunchDarkly.OpenFeature.ServerProvider.Tests/ProviderTests.cs
@@ -156,6 +156,21 @@ namespace LaunchDarkly.OpenFeature.ServerProvider.Tests
         }
 
         [Fact(Timeout = 5000)]
+        public async Task ItDoesNotTimeOutInitializationWhenTheStartWaitTimeIsZero()
+        {
+            var provider = new Provider(Configuration.Builder("")
+                .DataSource(Components.ExternalUpdatesOnly)
+                .Events(Components.NoEvents)
+                .StartWaitTime(TimeSpan.Zero)
+                .Build());
+
+            var initialization = provider.InitializeAsync(EvaluationContext.Empty);
+            await Task.Delay(100);
+
+            Assert.False(initialization.IsFaulted);
+        }
+
+        [Fact(Timeout = 5000)]
         public async Task ItDoesNotTimeOutInitializationWhenTheClientBecomesReady()
         {
             var mockClient = new Mock<ILdClient>();


### PR DESCRIPTION
`SetProviderAsync` never completed while LaunchDarkly was unreachable, so applications that await it could not start; the provider now gives up waiting after the configured `StartWaitTime`.

Closes #50.

- `Provider(Configuration)` uses `config.StartWaitTime` as an initialization timeout; on expiry `InitializeAsync` fails with `LaunchDarklyProviderInitException` and logs a warning
- The client keeps connecting, so a later successful connection emits a `ProviderReady` event and the provider recovers — matching the direction in #50 ("transition to a provider error state and then continue to attempt to recover")
- Evaluations during the error state are unaffected: the LaunchDarkly client serves whatever data it has, or falls back to defaults
- `Provider(ILdClient)` (internal, and used by tests) still waits indefinitely, since there is no configuration to read a timeout from

@cursor review

<details>
<summary>Implementation details</summary>

**Mechanism**

`InitializeAsync` schedules a `Task.Delay(StartWaitTime)` continuation that, if `_initCompletion` has not completed, sets the provider status to `Error` and faults the task. Setting the status also consumes `StatusProvider`'s "first event" suppression, which is what allows the subsequent `Valid` status to emit a real `ProviderReady` event instead of being swallowed as a duplicate of initialization.

**Semantics worth a reviewer's opinion**

`new LdClient(config)` already blocks for up to `StartWaitTime` in the provider constructor, and this timeout starts when `InitializeAsync` runs, so a totally offline start can now wait up to two `StartWaitTime` intervals before `SetProviderAsync` returns. Measuring the timeout from the constructor instead would require threading a start timestamp through, and would make `StartWaitTime` mean something different for the provider than for the SDK. Happy to change it if the doubled worst case is not acceptable.

**Alternatives considered**

- Documenting `SetProviderAsync(provider).WaitAsync(timeout)` (the workaround in #50): leaves the provider without a state transition and the application without an event to recover on.
- Completing initialization successfully on timeout: would report `READY` for a provider that has never received data.

**Testing**

`dotnet test test/LaunchDarkly.OpenFeature.ServerProvider.Tests -f net8.0` — 62 tests pass, including a timeout test, a test that a client which becomes ready before the timeout does not fail, and a test that the provider still emits `ProviderReady` after a timed-out initialization. `dotnet build src/LaunchDarkly.OpenFeature.ServerProvider -f netstandard2.0` succeeds with no warnings.

No visual preview applies — this is a server-side provider change.

</details>


Link to Devin session: https://app.devin.ai/sessions/0c452d209ec54b068ba120b4c92b8f6c
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Stops `InitializeAsync` / `SetProviderAsync` from hanging forever when LaunchDarkly never becomes ready. The provider now treats `Configuration.StartWaitTime` as an init timeout (unless it is zero, which still means wait indefinitely).
> 
> On expiry it logs a warning, sets provider status to **Error**, and faults init with `LaunchDarklyProviderInitException`. The SDK client keeps connecting, so a later `Valid` data source still emits **Ready** and evaluations are not blocked. Ready/timeout completion is serialized with `_initLock`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a7f3ed7902ac189b870a8eac6d80a976df17f17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->